### PR TITLE
Remoção de imports desnecessarios

### DIFF
--- a/src/servico/NotificacaoService.java
+++ b/src/servico/NotificacaoService.java
@@ -8,7 +8,6 @@ import datamapper.AusenciaJpaController;
 import datamapper.ProfessorJpaController;
 import datamapper.exceptions.NonexistentEntityException;
 import dominio.Ausencia;
-import dominio.EstadoAusencia;
 import dominio.Professor;
 import modelo.AusenciaModel;
 import java.text.ParseException;


### PR DESCRIPTION
De acordo com o Codacy, havia o uso desnecessário de um import(dominio.EstadoAusencia).
Tal import foi removido.